### PR TITLE
Add persona memory architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ Additional docs:
 - [Architecture](docs/ARCHITECTURE.md)
 - [Status](docs/STATUS.md)
 - [Unified Vultr Setup](docs/UNIFIED_VULTR_ARCHITECTURE.md)
+
+## Persona Memory Architecture
+See [docs/PERSONA_MEMORY_ARCHITECTURE.md](docs/PERSONA_MEMORY_ARCHITECTURE.md) for the proposed four-layer memory system and routing approach.
+

--- a/docs/CONFIGURATION_STANDARDS.md
+++ b/docs/CONFIGURATION_STANDARDS.md
@@ -180,3 +180,18 @@ Following these configuration standards will ensure:
 4. Clear separation of concerns between configuration types
 
 For questions or improvements to these standards, please file an issue or pull request.
+
+### Persona Memory Variables
+
+The persona memory system uses separate Redis databases and PostgreSQL schemas for each persona. Example variables:
+
+```
+REDIS_DB_CHERRY=0
+REDIS_DB_SOPHIA=1
+REDIS_DB_KAREN=2
+POSTGRES_SCHEMA_CHERRY=cherry
+POSTGRES_SCHEMA_SOPHIA=sophia
+POSTGRES_SCHEMA_KAREN=karen
+NEO4J_URL=bolt://localhost:7687
+```
+

--- a/docs/PERSONA_MEMORY_ARCHITECTURE.md
+++ b/docs/PERSONA_MEMORY_ARCHITECTURE.md
@@ -1,0 +1,44 @@
+# Persona-Aware Memory Architecture
+
+This document outlines the proposed four-layer memory system and persona routing approach.
+
+## Four-Layer Memory Stack
+
+1. **Episodic Memory – Redis Cluster**
+   - Separate databases per persona (Cherry, Sophia, Karen).
+   - Short term context with TTL matching domain needs.
+2. **Semantic Memory – Weaviate Vector DB**
+   - Namespaces per persona with cross references for shared concepts.
+3. **Procedural Memory – PostgreSQL**
+   - Persona specific schemas storing workflow information.
+4. **Meta-Memory – Neo4j**
+   - Knowledge graph describing relationships between personas and tasks.
+
+## PersonaMemoryRouter
+
+A new `PersonaMemoryRouter` will route queries across memory layers based on the active persona.
+
+```python
+class PersonaMemoryRouter:
+    def __init__(self, active_persona: str):
+        self.persona = active_persona
+        self.episodic = RedisCluster(namespace=active_persona)
+        self.semantic = WeaviateClient(class_prefix=active_persona)
+        self.procedural = PostgresSchema(schema_name=active_persona)
+        self.meta = Neo4jGraph()
+
+    def query(self, query: str, context: dict):
+        episodic_results = self.episodic.search(context.get("time_window"))
+        semantic_hits = self.semantic.hybrid_search(query)
+        procedural_flows = self.procedural.match_workflow(context)
+        return self._rank_results(episodic_results, semantic_hits, procedural_flows)
+```
+
+## Implementation Tasks
+
+- Consolidate existing memory managers under `core/services/memory/unified_memory.py`.
+- Add Neo4j integration for meta-memory and cross-persona queries.
+- Extend configuration files to support persona specific Redis DBs and Postgres schemas.
+- Update documentation and `.env.example` with new environment variables.
+- Provide unit tests ensuring persona isolation and cross-persona queries.
+

--- a/env.example
+++ b/env.example
@@ -31,3 +31,12 @@ LOG_LEVEL=INFO
 # Optional Services
 REDIS_URL=redis://localhost:6379
 WEAVIATE_URL=http://localhost:8080
+
+# Persona specific memory settings
+REDIS_DB_CHERRY=0
+REDIS_DB_SOPHIA=1
+REDIS_DB_KAREN=2
+POSTGRES_SCHEMA_CHERRY=cherry
+POSTGRES_SCHEMA_SOPHIA=sophia
+POSTGRES_SCHEMA_KAREN=karen
+NEO4J_URL=bolt://localhost:7687


### PR DESCRIPTION
## Summary
- document 4-layer persona memory design
- reference memory doc from README
- add persona variables to example env file
- mention persona memory variables in configuration standards

## Testing
- `./run_tests.sh simple` *(fails: Could not install pytest-cov and tests fail due to missing httpx)*

------
https://chatgpt.com/codex/tasks/task_e_683bbe1e5dfc8328ab2d8125be412fde