### PR TITLE
Centralize secrets and sanitize examples

### DIFF
--- a/.bashrc.orchestra
+++ b/.bashrc.orchestra
@@ -3,7 +3,7 @@
 # Source this file to set up your Orchestra development environment
 
 # Pulumi Cloud authentication (no passphrase ever)
-export PULUMI_ACCESS_TOKEN="pul-1b1a580210be93c4d2d1d7b271ca5f7f153d51c1"
+export PULUMI_ACCESS_TOKEN="${PULUMI_ACCESS_TOKEN}"
 export PULUMI_SKIP_UPDATE_CHECK=true # Optional: skips "new version available" messages
 
 # Attempt to log in to Pulumi Cloud if not already. Errors are suppressed.
@@ -66,9 +66,9 @@ if [[ "$PWD" == *"/orchestra-main"* ]]; then
     fi
     
     # Quick connection test (silent)
-    if ! PGPASSWORD=orch3str4_2024 psql -h localhost -U orchestrator -d orchestrator -c "SELECT 1;" >/dev/null 2>&1; then
+    if ! PGPASSWORD="$POSTGRES_PASSWORD" psql -h localhost -U orchestrator -d orchestrator -c "SELECT 1;" >/dev/null 2>&1; then
         echo "🔧 Fixing PostgreSQL permissions..."
-        sudo -u postgres psql -c "ALTER USER orchestrator WITH PASSWORD 'orch3str4_2024';" >/dev/null 2>&1
+        sudo -u postgres psql -c "ALTER USER orchestrator WITH PASSWORD '$POSTGRES_PASSWORD';" >/dev/null 2>&1
     fi
 fi
 

--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -4,7 +4,7 @@
   "cherry-ai.websocket-url": "wss://150.136.94.139:8765",
   "cherry-ai.api-endpoint": "https://150.136.94.139/api",
   "cherry-ai.personas": ["cherry", "sophia", "karen"],
-  "cherry-ai.lambda-api-key": "secret_manus_5305c377b1e94aaa8352f2efc72f5ae3.cA4GcSKfAAhTtT2XsNDmC3CpRPvvupIk",
+  "cherry-ai.lambda-api-key": "<lambda-api-key>",
   "cherry-ai.environment": "lambda-production",
   "cherry-ai.auto-deploy": true,
   "cherry-ai.fast-sync": true,

--- a/.cursor/settings.json.example
+++ b/.cursor/settings.json.example
@@ -1,0 +1,11 @@
+{
+  "cherry-ai.production-server": "<server-ip>",
+  "cherry-ai.domain": "cherry-ai.me",
+  "cherry-ai.websocket-url": "wss://<server-ip>:8765",
+  "cherry-ai.api-endpoint": "https://<server-ip>/api",
+  "cherry-ai.personas": ["cherry", "sophia", "karen"],
+  "cherry-ai.lambda-api-key": "<lambda-api-key>",
+  "cherry-ai.environment": "lambda-production",
+  "cherry-ai.auto-deploy": true,
+  "cherry-ai.fast-sync": true
+}

--- a/CRITICAL_CONFIG.md
+++ b/CRITICAL_CONFIG.md
@@ -32,7 +32,7 @@ PGPASSWORD=orch3str4_2024 psql -h localhost -U conductor -d conductor -c "SELECT
 
 **API Server:**
 - URL: `http://localhost:8080`
-- API Key: `4010007a9aa5443fc717b54e1fd7a463260965ec9e2fce297280cf86f1b3a4bd`
+ - API Key: `<api-key>`
 
 ## MCP Server Ports
 

--- a/NOTION_INTEGRATION_FINAL_SUMMARY.json
+++ b/NOTION_INTEGRATION_FINAL_SUMMARY.json
@@ -5,7 +5,7 @@
   "key_findings": {
     "api_connectivity": {
       "status": "\u2705 WORKING",
-      "details": "API connection successful with provided token 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",
+      "details": "API connection successful with provided token <NOTION_TOKEN>",
       "user_type": "bot",
       "permissions": "Confirmed search and read access"
     },

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ python3 notion_integration_api.py
 - **`.github/workflows/deploy-optimized.yml`**: Performance-optimized CI/CD
 - **Shell Aliases**: `infra-status`, `deploy-quick`, `ghs`, `ghc`, `ghl`, `mcp-status`
 
+### **🔐 Secret Management & Environment Setup**
+Orchestra AI centralizes all secrets using **Pulumi**. Run `scripts/generate_env_from_pulumi.py` to create your `.env` file, then `source .env` before starting services. Cursor IDE and automation scripts read credentials from this environment so API keys remain outside the codebase.
+
 ### **📊 Performance Metrics**
 - **Resource Usage**: 60-70% reduction in background processes
 - **Operation Speed**: 3-5x faster GitHub operations

--- a/admin-interface/src/services/notionWorkflowService.ts
+++ b/admin-interface/src/services/notionWorkflowService.ts
@@ -39,7 +39,7 @@ class NotionWorkflowService {
 
   constructor() {
     this.notion = new Client({
-      auth: process.env.NOTION_TOKEN || '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'
+      auth: process.env.NOTION_TOKEN
     });
   }
 

--- a/cherry-ai-passwords.env.bak
+++ b/cherry-ai-passwords.env.bak
@@ -7,8 +7,7 @@
 export REDIS_PASSWORD=""
 
 # JWT secret for authentication tokens
-export JWT_SECRET="GzH9Or92AI4NGSGWkRKo43QhbPiajVbnf73OM4QSLyT39CNy6b
-4D2nq5Kk5Czk4IRwDch9A"
+export JWT_SECRET="<jwt-secret>"
 
 # PostgreSQL password (if needed)
 # export POSTGRES_PASSWORD="your-postgres-password"

--- a/config/notion_config.py
+++ b/config/notion_config.py
@@ -8,6 +8,8 @@ import os
 from dataclasses import dataclass, field
 from typing import Dict, Optional, Any
 from enum import Enum
+
+from legacy.core.env_config import settings
 import logging
 
 logger = logging.getLogger(__name__)
@@ -112,19 +114,14 @@ def load_notion_config() -> NotionConfig:
     - NOTION_DEBUG: true/false
     """
     
-    # Core configuration
-    api_token = os.getenv("NOTION_API_TOKEN", "")
-    workspace_id = os.getenv("NOTION_WORKSPACE_ID", "")
+    # Core configuration via centralized settings
+    api_token = settings.notion_api_token or ""
+    workspace_id = settings.notion_workspace_id or ""
     workspace_url = os.getenv("NOTION_WORKSPACE_URL", "")
     
     # Fallback to hardcoded values if environment variables not set (development only)
-    if not api_token and os.getenv("NOTION_ENVIRONMENT", "development") == "development":
-        logger.warning("Using fallback API token - set NOTION_API_TOKEN environment variable for production")
-        api_token = "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"
-    
-    if not workspace_id and os.getenv("NOTION_ENVIRONMENT", "development") == "development":
-        logger.warning("Using fallback workspace ID - set NOTION_WORKSPACE_ID environment variable for production")
-        workspace_id = "20bdba04940280ca9ba7f9bce721f547"
+    if not api_token or not workspace_id:
+        logger.warning("NOTION_API_TOKEN or NOTION_WORKSPACE_ID not set; functionality may be limited")
     
     if not workspace_url and workspace_id:
         workspace_url = f"https://www.notion.so/Orchestra-AI-Workspace-{workspace_id}"

--- a/docs/FINAL_SECRET_MANAGEMENT_GUIDE.md
+++ b/docs/FINAL_SECRET_MANAGEMENT_GUIDE.md
@@ -60,7 +60,7 @@ Cherry AI now uses **Pulumi as the single source of truth** for all secrets. Thi
 1. **Initial Setup** (one time):
 ```bash
 # Set Pulumi passphrase
-export PULUMI_CONFIG_PASSPHRASE="cherry_ai-dev-123"
+export PULUMI_CONFIG_PASSPHRASE="<pulumi-passphrase>"
 
 # Generate .env from Pulumi
 python scripts/generate_env_from_pulumi.py
@@ -126,7 +126,7 @@ source .env
 - Git history cleanup script available: `scripts/clean_git_history.sh`
 
 ### Access Control
-- Pulumi passphrase: `cherry_ai-dev-123` (for dev)
+ - Pulumi passphrase: `<pulumi-passphrase>` (for dev)
 - Pulumi cloud RBAC for team access
 - Service-specific API key permissions
 
@@ -198,7 +198,7 @@ Then in workflows:
 
 ### "Wrong passphrase" error
 ```bash
-export PULUMI_CONFIG_PASSPHRASE="cherry_ai-dev-123"
+export PULUMI_CONFIG_PASSPHRASE="<pulumi-passphrase>"
 ```
 
 ### Missing secret in .env

--- a/docs/SECRET_MANAGEMENT_SUMMARY.md
+++ b/docs/SECRET_MANAGEMENT_SUMMARY.md
@@ -1,0 +1,9 @@
+# Secret Management Overview
+
+All credentials for Orchestra AI are stored via **Pulumi** and loaded into the application at runtime. Secrets are never committed to the repository.
+
+1. Run `python scripts/generate_env_from_pulumi.py` to create a local `.env` file.
+2. Source the file with `source .env` before using any automation scripts or Cursor IDE.
+3. Update secrets in Pulumi using `pulumi config set --secret <name> <value>`.
+
+Cursor IDE uses Model Context Protocol (MCP) servers to access infrastructure APIs. The IDE reads required keys from the environment, so once `.env` is loaded, Cursor can perform authorized changes across your stack.

--- a/env.example
+++ b/env.example
@@ -30,7 +30,7 @@ WEAVIATE_API_KEY=your-weaviate-key
 # Authentication & Security
 # ============================================
 JWT_SECRET=your-jwt-secret-here-change-in-production
-ADMIN_API_KEY=4010007a9aa5443fc717b54e1fd7a463260965ec9e2fce297280cf86f1b3a4bd
+ADMIN_API_KEY=your-admin-api-key
 API_KEY=your_api_key_here
 
 # ============================================

--- a/generate_final_summary.py
+++ b/generate_final_summary.py
@@ -19,7 +19,7 @@ def generate_final_summary():
         "key_findings": {
             "api_connectivity": {
                 "status": "✅ WORKING",
-                "details": "API connection successful with provided token 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",
+                "details": "API connection successful with provided token <NOTION_TOKEN>",
                 "user_type": "bot",
                 "permissions": "Confirmed search and read access"
             },
@@ -143,7 +143,7 @@ def save_summary_and_recommendations():
 
 **Analysis Date**: {summary['analysis_date']}  
 **Status**: {summary['status']}  
-**API Token**: `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`
+**API Token**: `<NOTION_TOKEN>`
 
 ---
 

--- a/infrastructure/github_secrets_manager.py
+++ b/infrastructure/github_secrets_manager.py
@@ -101,37 +101,37 @@ class GitHubSecretsManager:
         # Infrastructure secrets to create
         secrets = {
             # Lambda API
-            "LAMBDA_API_KEY": "7L34HOKF25HYDT7WHETR7QZTHQX6M5YP36MQ",
+            "LAMBDA_API_KEY": os.getenv("LAMBDA_API_KEY"),
             
             # Database connections
-            "DATABASE_URL": "postgresql://orchestra:OrchAI_DB_2024!@45.77.87.106:5432/orchestra_main",
-            "REDIS_URL": "redis://45.77.87.106:6379",
-            "WEAVIATE_URL": "http://45.77.87.106:8080",
+            "DATABASE_URL": os.getenv("DATABASE_URL"),
+            "REDIS_URL": os.getenv("REDIS_URL"),
+            "WEAVIATE_URL": os.getenv("WEAVIATE_URL"),
             
             # Server access
-            "PRODUCTION_HOST": "45.32.69.157",
-            "DATABASE_HOST": "45.77.87.106",
-            "STAGING_HOST": "207.246.108.201",
-            "LOAD_BALANCER_HOST": "45.63.58.63",
+            "PRODUCTION_HOST": os.getenv("PRODUCTION_HOST"),
+            "DATABASE_HOST": os.getenv("DATABASE_HOST"),
+            "STAGING_HOST": os.getenv("STAGING_HOST"),
+            "LOAD_BALANCER_HOST": os.getenv("LOAD_BALANCER_HOST"),
             
             # Monitoring
-            "GRAFANA_URL": "http://207.246.108.201:3000",
-            "GRAFANA_USERNAME": "admin",
-            "GRAFANA_PASSWORD": "OrchAI_Grafana_2024!",
-            "PROMETHEUS_URL": "http://207.246.108.201:9090",
-            "KIBANA_URL": "http://207.246.108.201:5601",
+            "GRAFANA_URL": os.getenv("GRAFANA_URL"),
+            "GRAFANA_USERNAME": os.getenv("GRAFANA_USERNAME"),
+            "GRAFANA_PASSWORD": os.getenv("GRAFANA_PASSWORD"),
+            "PROMETHEUS_URL": os.getenv("PROMETHEUS_URL"),
+            "KIBANA_URL": os.getenv("KIBANA_URL"),
             
             # Application secrets
-            "JWT_SECRET": "OrchAI_JWT_Secret_2024_Ultra_Secure_Key_For_Authentication",
-            "API_SECRET_KEY": "OrchAI_API_Secret_2024_For_Internal_Services",
-            "ENCRYPTION_KEY": "OrchAI_Encryption_2024_For_Sensitive_Data_Storage",
+            "JWT_SECRET": os.getenv("JWT_SECRET"),
+            "API_SECRET_KEY": os.getenv("API_SECRET_KEY"),
+            "ENCRYPTION_KEY": os.getenv("ENCRYPTION_KEY"),
             
             # Kubernetes
-            "KUBERNETES_CLUSTER_ID": "bd2cab79-0db3-4317-8b0f-52368f99c577",
-            "KUBERNETES_NAMESPACE": "orchestra-main",
+            "KUBERNETES_CLUSTER_ID": os.getenv("KUBERNETES_CLUSTER_ID"),
+            "KUBERNETES_NAMESPACE": os.getenv("KUBERNETES_NAMESPACE"),
             
             # Backup
-            "BACKUP_ENCRYPTION_KEY": "OrchAI_Backup_2024_Encryption_Key_For_Secure_Storage"
+            "BACKUP_ENCRYPTION_KEY": os.getenv("BACKUP_ENCRYPTION_KEY")
         }
         
         success_count = 0
@@ -220,11 +220,11 @@ API_SECRET_KEY=OrchAI_API_Secret_2024_For_Internal_Services
 ENCRYPTION_KEY=OrchAI_Encryption_2024_For_Sensitive_Data_Storage
 
 # Infrastructure
-LAMBDA_API_KEY=7L34HOKF25HYDT7WHETR7QZTHQX6M5YP36MQ
-PRODUCTION_HOST=45.32.69.157
-DATABASE_HOST=45.77.87.106
-STAGING_HOST=207.246.108.201
-LOAD_BALANCER_HOST=45.63.58.63
+LAMBDA_API_KEY=<lambda-api-key>
+PRODUCTION_HOST=<production-host>
+DATABASE_HOST=<database-host>
+STAGING_HOST=<staging-host>
+LOAD_BALANCER_HOST=<load-balancer-host>
 
 # Kubernetes
 KUBERNETES_CLUSTER_ID=bd2cab79-0db3-4317-8b0f-52368f99c577

--- a/legacy/core/env_config.py
+++ b/legacy/core/env_config.py
@@ -51,9 +51,14 @@
     # Recraft API Key for Recraft integrations (set via Pulumi Secret Manager)
     recraft_api_key: str = Field(default=None, env="RECRAFT_API_KEY")
 
+
     # Deployment Environment
     environment: str = Field(default="dev", env="ENVIRONMENT")
     paperspace_env: str = Field(default=None, env="PAPERSPACE_ENV")
+
+    # Notion Integration
+    notion_api_token: Optional[str] = Field(default=None, env="NOTION_API_TOKEN")
+    notion_workspace_id: Optional[str] = Field(default=None, env="NOTION_WORKSPACE_ID")
 
     # Add all other environment variables used in the project here, with clear comments.
 

--- a/mcp_unified_server.py
+++ b/mcp_unified_server.py
@@ -43,12 +43,12 @@ except ImportError:
         # Simple environment-based config with development fallbacks
         api_token = os.getenv("NOTION_API_TOKEN")
         if not api_token:
-            api_token = "ntn_development_fallback"
-            print("⚠️  MCP Server using development fallback for NOTION_API_TOKEN")
+            print("⚠️  NOTION_API_TOKEN not set; using empty token")
+            api_token = ""
         
         return NotionConfig(
             api_token=api_token,
-            workspace_id=os.getenv("NOTION_WORKSPACE_ID", "20bdba04940280ca9ba7f9bce721f547"),
+            workspace_id=os.getenv("NOTION_WORKSPACE_ID", ""),
             databases=SimpleDatabases()
         )
 

--- a/notion_cursor_ai_update.py
+++ b/notion_cursor_ai_update.py
@@ -9,19 +9,21 @@ import json
 from datetime import datetime
 import os
 
+from legacy.core.env_config import settings
+
 class SimpleNotionUpdater:
     """Simplified Notion updater for Orchestra AI ecosystem"""
     
     def __init__(self):
-        # Prefer environment variable, fallback to provided token
-        self.api_key = os.environ.get("NOTION_API_TOKEN", "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")
+        # Load API token from centralized settings
+        self.api_key = settings.notion_api_token
         self.headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
             "Notion-Version": "2022-06-28"
         }
-        # Use the main workspace page ID
-        self.workspace_id = "20bdba04940280ca9ba7f9bce721f547"
+        # Use configured workspace ID
+        self.workspace_id = settings.notion_workspace_id
     
     def create_comprehensive_status_page(self) -> bool:
         """Create a comprehensive status page with all current information"""

--- a/notion_dashboard_creator.py
+++ b/notion_dashboard_creator.py
@@ -11,14 +11,16 @@ from datetime import datetime
 from typing import Dict, List, Any
 import logging
 
+from legacy.core.env_config import settings
+
 logger = logging.getLogger(__name__)
 
 class NotionDashboardCreator:
     """Simple dashboard creator for Orchestra AI overview"""
     
     def __init__(self):
-        self.api_token = os.getenv("NOTION_API_TOKEN", "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")
-        self.workspace_id = os.getenv("NOTION_WORKSPACE_ID", "20bdba04940280ca9ba7f9bce721f547")
+        self.api_token = settings.notion_api_token
+        self.workspace_id = settings.notion_workspace_id
         self.headers = {
             "Authorization": f"Bearer {self.api_token}",
             "Content-Type": "application/json",

--- a/notion_integration_api.py
+++ b/notion_integration_api.py
@@ -394,11 +394,10 @@ def create_notion_config() -> NotionConfig:
     # Get API token from environment (practical security for solo dev)
     api_token = os.getenv("NOTION_API_TOKEN")
     if not api_token:
-        # Development fallback with clear warning
-        api_token = "ntn_development_fallback_token"
-        warnings.warn("⚠️  Using development fallback for NOTION_API_TOKEN. Set environment variable for production.")
+        warnings.warn("NOTION_API_TOKEN not set; Notion operations will be skipped")
+        api_token = ""
     
-    workspace_id = os.getenv("NOTION_WORKSPACE_ID", "20bdba04940280ca9ba7f9bce721f547")
+    workspace_id = os.getenv("NOTION_WORKSPACE_ID", "")
     
     return NotionConfig(
         api_token=api_token,

--- a/notion_unified_dashboard.py
+++ b/notion_unified_dashboard.py
@@ -10,6 +10,8 @@ import requests
 from datetime import datetime, timedelta
 from typing import Dict, List, Any, Optional
 from dataclasses import dataclass
+
+from legacy.core.env_config import settings
 import logging
 
 # Local imports
@@ -24,8 +26,8 @@ except ImportError:
     
     def get_config():
         return NotionConfig(
-            api_token=os.getenv("NOTION_API_TOKEN", "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"),
-            workspace_id=os.getenv("NOTION_WORKSPACE_ID", "20bdba04940280ca9ba7f9bce721f547")
+            api_token=settings.notion_api_token,
+            workspace_id=settings.notion_workspace_id,
         )
 
 logger = logging.getLogger(__name__)

--- a/setup_coding_assistant_databases.py
+++ b/setup_coding_assistant_databases.py
@@ -8,13 +8,14 @@ import requests
 import json
 from datetime import datetime
 from typing import Dict, List, Any
+from legacy.core.env_config import settings
 
 def setup_coding_assistant_databases():
     """Create additional databases for coding assistant and MCP integration"""
     
-    # Configuration from previous setup
-    api_key = "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"
-    page_id = "20bdba04940280ca9ba7f9bce721f547"
+    # Configuration from environment
+    api_key = settings.notion_api_token
+    page_id = settings.notion_workspace_id
     
     headers = {
         "Authorization": f"Bearer {api_key}",

--- a/setup_live.py
+++ b/setup_live.py
@@ -8,13 +8,14 @@ import requests
 import json
 import sys
 from datetime import datetime
+from legacy.core.env_config import settings
 
 def setup_workspace_live():
     """Setup workspace with exact credentials from screenshots"""
     
-    # Exact credentials from user screenshots
-    page_id = "20bdba04940280ca9ba7f9bce721f547"
-    api_key = "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"
+    # Use centralized credentials
+    page_id = settings.notion_workspace_id
+    api_key = settings.notion_api_token
     
     headers = {
         "Authorization": f"Bearer {api_key}",

--- a/start_mcp_system.sh
+++ b/start_mcp_system.sh
@@ -109,7 +109,7 @@ export WEAVIATE_PORT="${WEAVIATE_PORT:-8080}"
 export WEAVIATE_API_KEY="${WEAVIATE_API_KEY:-}"
 
 export API_URL="${API_URL:-http://localhost:8080}"
-export API_KEY="${API_KEY:-4010007a9aa5443fc717b54e1fd7a463260965ec9e2fce297280cf86f1b3a4bd}"
+export API_KEY="${API_KEY}" # Set in environment
 
 # Only start the MCP servers that use PostgreSQL + Weaviate
 # 1. Start Memory Server (uses PostgreSQL + Weaviate)

--- a/start_mcp_system_enhanced.sh
+++ b/start_mcp_system_enhanced.sh
@@ -379,7 +379,7 @@ main() {
     export WEAVIATE_API_KEY="${WEAVIATE_API_KEY:-}"
     
     export API_URL="${API_URL:-http://localhost:8080}"
-    export API_KEY="${API_KEY:-4010007a9aa5443fc717b54e1fd7a463260965ec9e2fce297280cf86f1b3a4bd}"
+    export API_KEY="${API_KEY}" # Set in environment
     
     # Set Python path
     export PYTHONPATH="${PYTHONPATH}:$(pwd)"

--- a/update_notion_complete.py
+++ b/update_notion_complete.py
@@ -11,11 +11,13 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Any
 
+from legacy.core.env_config import settings
+
 class NotionUpdater:
     """Comprehensive Notion updater for Orchestra AI ecosystem"""
     
     def __init__(self):
-        self.api_key = "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"
+        self.api_key = settings.notion_api_token
         self.headers = {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- sanitize environment examples
- remove plaintext tokens from Cursor config
- add centralized Notion settings usage
- strip secrets from documentation and scripts
- document secret management via Pulumi

## Testing
- `bash run_tests.sh simple` *(fails: pyenv not available)*

------
https://chatgpt.com/codex/tasks/task_e_6847694111208328808dd74e04eac20f