### PR TITLE
Add Cursor IaC agent docs and config

### DIFF
--- a/.cursor/agents/iac_agent.yaml
+++ b/.cursor/agents/iac_agent.yaml
@@ -1,0 +1,18 @@
+name: IaC Specialist
+system_prompt: |
+  You are an expert infrastructure engineer specializing in Pulumi.
+  Focus on Lambda Labs Cloud deployments and integrations with
+  Weaviate, Pinecone, PostgreSQL and Redis.
+  Always follow these principles:
+  - Immutable infrastructure patterns
+  - Zero-downtime deployments
+  - Cost-optimized resource allocation
+
+tools:
+  - pulumi_preview
+  - cloud_cost_calculator
+  - security_scanner
+
+constraints:
+  max_parallel_env: 3
+  approval_threshold: medium_risk

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,8 @@
+{
+  "pre_commands": [
+    "pulumi stack select dev"
+  ],
+  "post_commands": [
+    "pulumi preview"
+  ]
+}

--- a/.cursor/environment/Dockerfile
+++ b/.cursor/environment/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y \
+    pulumi=3.50.0 \
+    python3-pip
+
+RUN pip3 install \
+    weaviate-client \
+    pinecone-client \
+    psycopg2-binary \
+    redis

--- a/.cursor/rules/iac.mdc
+++ b/.cursor/rules/iac.mdc
@@ -1,0 +1,22 @@
+---
+description: Pulumi Infrastructure-as-Code standards
+globs: ["**/Pulumi.yaml", "**/Pulumi.*.yaml", "infrastructure/**/*.py"]
+autoAttach: true
+priority: medium
+---
+
+# IaC Standards
+
+## Pulumi Rules
+- Use stack-specific configuration for Lambda Labs Cloud
+- Tag all resources with environment and owner metadata
+- Use `pulumi.Output.secret` for sensitive values
+- Provide reusable components for Weaviate and Pinecone
+
+## Data Services
+- Ensure PostgreSQL and Redis instances enable encryption and backups
+
+## Documentation
+- Auto-generate README.md for new components
+- Maintain changelog entries
+- Include cost estimates

--- a/CURSOR_IAC_AGENT_MODE.md
+++ b/CURSOR_IAC_AGENT_MODE.md
@@ -1,0 +1,67 @@
+# Cursor IaC Agent Mode Setup
+
+This guide outlines how to enable a specialized Infrastructure-as-Code agent in Cursor IDE for Orchestra AI.
+
+## 1. Base Configuration
+- Upgrade to **Cursor Pro** for advanced IaC features (already enabled).
+- Install Pulumi and required Python packages in your workspace.
+- Grant GitHub read/write access to repositories and configure branch protection exemptions for the agent.
+
+## 2. IaC Rules
+Create `.cursor/rules/iac.mdc` with Pulumi standards:
+- Lambda Labs stack configuration and tagging rules
+- Security baseline for PostgreSQL and Redis
+- Auto-generated component READMEs
+
+## 3. Agent Profile
+Add `.cursor/agents/iac_agent.yaml`:
+```yaml
+name: IaC Specialist
+system_prompt: |
+  You are an expert infrastructure engineer specializing in Pulumi.
+  Focus on Lambda Labs Cloud with Weaviate, Pinecone, PostgreSQL and Redis integrations.
+
+tools:
+  - pulumi_preview
+  - cloud_cost_calculator
+  - security_scanner
+constraints:
+  max_parallel_env: 3
+  approval_threshold: medium_risk
+```
+
+## 4. Background Environment
+Place the Dockerfile and runtime config in `.cursor/environment/`:
+```Dockerfile
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y \
+    pulumi=3.50.0 \
+    python3-pip
+
+RUN pip3 install \
+    weaviate-client \
+    pinecone-client \
+    psycopg2-binary \
+    redis
+```
+```json
+{
+  "pre_commands": ["pulumi stack select dev"],
+  "post_commands": ["pulumi preview"]
+}
+```
+
+## 5. Workflow Automation
+Example command in Cursor chat:
+```
+"Create autoscaling group with blue/green deployment pattern for ECS cluster"
+```
+The agent generates Pulumi components, configures infrastructure and runs previews in a staging stack.
+
+## 6. Security and Testing
+Use `.cursor/secrets.yaml` for encrypted variables and define access controls in `cursor-permissions.json`. Each agent run automatically validates Pulumi stacks, checks policies, simulates costs and produces a security report.
+
+## 7. Approval Gates
+Critical resources such as database instances can require manual approval via `.cursor/approvals.yaml`, and monthly cost thresholds can be enforced.
+
+This configuration enables reliable Pulumi automation with Lambda Labs Cloud while keeping security and cost in check.

--- a/README.md
+++ b/README.md
@@ -282,7 +282,8 @@ Orchestra AI centralizes all secrets using **Pulumi**. Run `scripts/generate_env
 
 ### **Development Tools Integration**
 - **Cursor AI**: Backend development with Claude models + persona integration
-- **Continue.dev**: UI development with UI-GPT-4O + persona coordination  
+- **Cursor IaC Agent Mode**: Automated Pulumi workflows for Lambda Labs and data services (see `CURSOR_IAC_AGENT_MODE.md`)
+- **Continue.dev**: UI development with UI-GPT-4O + persona coordination
 - **MCP Protocol**: Seamless tool coordination across all AI assistants
 - **Real-time Sync**: Shared context and cross-tool communication
 


### PR DESCRIPTION
## Summary
- document how to enable a custom IaC agent in Cursor for Pulumi
- add IaC rule file focused on Pulumi components
- define IaC agent profile and environment setup for Lambda Labs
- mention Cursor IaC agent mode in README

## Testing
- `./run_tests.sh simple` *(fails: pyenv version not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684bbce2280083289cabe5b875a07f8e