### PR TITLE
Refine conversations endpoint and model imports

### DIFF
--- a/database/init/02-enhanced-conversations.sql
+++ b/database/init/02-enhanced-conversations.sql
@@ -1,0 +1,18 @@
+-- Enhanced conversations table for Sophia
+CREATE TABLE IF NOT EXISTS enhanced_conversations (
+    id SERIAL PRIMARY KEY,
+    gong_call_id VARCHAR(255) UNIQUE,
+    title TEXT,
+    duration INTEGER,
+    apartment_relevance DECIMAL(5,2),
+    business_value DECIMAL(12,2),
+    call_outcome VARCHAR(100),
+    competitive_mentions JSONB,
+    sophia_insights JSONB,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Performance indexes
+CREATE INDEX IF NOT EXISTS idx_apartment_relevance ON enhanced_conversations(apartment_relevance);
+CREATE INDEX IF NOT EXISTS idx_business_value ON enhanced_conversations(business_value);
+CREATE INDEX IF NOT EXISTS idx_call_outcome ON enhanced_conversations(call_outcome);

--- a/src/main.py
+++ b/src/main.py
@@ -14,6 +14,7 @@ from src.routes.chat import chat_bp
 from src.routes.search import search_bp
 from src.routes.personas import personas_bp
 from src.routes.health import health_bp
+from src.routes.conversations import conversations_bp
 from src.config import Config
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
@@ -29,6 +30,7 @@ app.register_blueprint(chat_bp, url_prefix='/api')
 app.register_blueprint(search_bp, url_prefix='/api')
 app.register_blueprint(personas_bp, url_prefix='/api')
 app.register_blueprint(health_bp, url_prefix='/api')
+app.register_blueprint(conversations_bp, url_prefix='/api')
 
 # Initialize database
 db.init_app(app)

--- a/src/models/conversation.py
+++ b/src/models/conversation.py
@@ -1,0 +1,33 @@
+from sqlalchemy import func
+from sqlalchemy.dialects.postgresql import JSONB
+from decimal import Decimal
+
+from .user import db
+
+class EnhancedConversation(db.Model):
+    __tablename__ = 'enhanced_conversations'
+
+    id = db.Column(db.Integer, primary_key=True)
+    gong_call_id = db.Column(db.String(255), unique=True)
+    title = db.Column(db.Text)
+    duration = db.Column(db.Integer)
+    apartment_relevance = db.Column(db.Numeric(5, 2))
+    business_value = db.Column(db.Numeric(12, 2))
+    call_outcome = db.Column(db.String(100))
+    competitive_mentions = db.Column(JSONB)
+    sophia_insights = db.Column(JSONB)
+    created_at = db.Column(db.DateTime, server_default=func.now())
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'gong_call_id': self.gong_call_id,
+            'title': self.title,
+            'duration': self.duration,
+            'apartment_relevance': float(self.apartment_relevance) if isinstance(self.apartment_relevance, Decimal) else self.apartment_relevance,
+            'business_value': float(self.business_value) if isinstance(self.business_value, Decimal) else self.business_value,
+            'call_outcome': self.call_outcome,
+            'competitive_mentions': self.competitive_mentions,
+            'sophia_insights': self.sophia_insights,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+        }

--- a/src/routes/conversations.py
+++ b/src/routes/conversations.py
@@ -1,0 +1,42 @@
+from flask import Blueprint, jsonify, request
+import os
+import redis
+import json
+
+from src.models.conversation import EnhancedConversation, db
+
+conversations_bp = Blueprint('conversations', __name__)
+
+# Initialize Redis connection if URL provided
+redis_url = os.getenv("REDIS_URL")
+redis_client = redis.Redis.from_url(redis_url) if redis_url else None
+
+DEFAULT_LIMIT = int(os.getenv("CONVERSATIONS_LIMIT", "10"))
+
+@conversations_bp.route('/conversations', methods=['GET'])
+def get_conversations():
+    """Retrieve conversations with optional caching and limiting."""
+    limit = request.args.get('limit', default=DEFAULT_LIMIT, type=int)
+    force_refresh = request.args.get('force_refresh', 'false').lower() == 'true'
+
+    cache_key = f'conversations:{limit}'
+
+    if redis_client and not force_refresh:
+        cached = redis_client.get(cache_key)
+        if cached:
+            return jsonify({'conversations': json.loads(cached)}), 200
+
+    query = EnhancedConversation.query.order_by(
+        EnhancedConversation.created_at.desc()
+    )
+    if limit:
+        query = query.limit(limit)
+
+    conversations = query.all()
+    results = [c.to_dict() for c in conversations]
+
+    if redis_client:
+        ttl = int(os.getenv('REDIS_TTL', '300'))
+        redis_client.setex(cache_key, ttl, json.dumps(results))
+
+    return jsonify({'conversations': results}), 200

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -311,6 +311,15 @@ class TestOrchestraAPI(unittest.TestCase):
         self.assertIn('results', data)
         self.assertIn('total_matches', data)
         self.assertEqual(data['query'], 'strategic')
+
+    def test_conversations_endpoint(self):
+        """Test conversations retrieval with limit"""
+        response = self.client.get('/api/conversations?limit=1')
+        self.assertEqual(response.status_code, 200)
+
+        data = json.loads(response.data)
+        self.assertIn('conversations', data)
+        self.assertLessEqual(len(data['conversations']), 1)
     
     def test_frontend_serving(self):
         """Test frontend serving"""


### PR DESCRIPTION
## Summary
- clean up `EnhancedConversation` model imports
- move JSON import in conversations route and set default limit

## Testing
- `pytest -q` *(fails: ImportError for `requests`)*

------
https://chatgpt.com/codex/tasks/task_e_6851ff98565c83289ca83ea72eae881f